### PR TITLE
Add `go-version-file` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 GitHub Action for setting up Golang via [actions/setup-go](https://github.com/actions/setup-go) coupled with [actions/cache](https://github.com/actions/cache) to cache Golang module and build cache directories.
 
-Designed for use with Linux based runners.
-
 ## Usage
 
 ```yaml
@@ -15,6 +13,8 @@ jobs:
       - name: Setup Golang with cache
         uses: flipgroup/action-golang-with-cache@main
         with:
-          version: ~1.17
+          version-file: go.mod
+          # alternatively, use `version` input
+          #version: ~1.18
           cache-key-suffix: key-suffix # optional input argument
 ```

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,8 @@ name: Golang with cache
 inputs:
   version:
     description: Golang version.
-    required: true
+  version-file:
+    description: Golang version from go.mod. Used in place of `version`.
   cache-key-suffix:
     description: Optional cache key suffix.
     default:
@@ -15,12 +16,19 @@ runs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ inputs.version }}
-    - name: Setup Golang caches
+        go-version-file: ${{ inputs.version-file }}
+    - name: Determine cache paths
+      id: golang-path
+      run: |
+        echo "::set-output name=build::$(go env GOCACHE)"
+        echo "::set-output name=module::$(go env GOMODCACHE)"
+      shell: bash
+    - name: Setup Golang cache
       uses: actions/cache@v3
       with:
         path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
+          ${{ steps.golang-path.outputs.build }}
+          ${{ steps.golang-path.outputs.module }}
         key: ${{ runner.os }}-golang${{ inputs.cache-key-suffix }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-golang${{ inputs.cache-key-suffix }}-


### PR DESCRIPTION
The https://github.com/actions/setup-go now conveniently supports setting the Golang version by reading a `go.mod` file.

This _should_ mean a project should only have to set the target Golang version once within a project. Win win 🎉 

Adding new `version-file` input to pass this filespec through. Input `version` is still safely supported - but obviously only one input should be passed to set version.

Also using `go env` calls to determine cache paths - rather than hard coded. This will mean the action can work on Windows/macOS runners if required.