### PR TITLE
Switch from `::set-output` control codes to environment file `$GITHUB_OUTPUT`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,8 @@ runs:
     - name: Determine cache paths
       id: golang-path
       run: |
-        echo "::set-output name=build::$(go env GOCACHE)"
-        echo "::set-output name=module::$(go env GOMODCACHE)"
+        echo "build=$(go env GOCACHE)" >>"$GITHUB_OUTPUT"
+        echo "module=$(go env GOMODCACHE)" >>"$GITHUB_OUTPUT"
       shell: bash
     - name: Setup Golang cache
       uses: actions/cache@v3


### PR DESCRIPTION
Why?

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/