### PR TITLE
Add dash (`-`) before `inputs.cache-key-suffix` in cache keys if defined for readability

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,6 @@ runs:
         path: |
           ${{ steps.golang-path.outputs.build }}
           ${{ steps.golang-path.outputs.module }}
-        key: ${{ runner.os }}-golang${{ inputs.cache-key-suffix }}-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-golang${{ inputs.cache-key-suffix && '-' }}${{ inputs.cache-key-suffix }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-golang${{ inputs.cache-key-suffix }}-
+          ${{ runner.os }}-golang${{ inputs.cache-key-suffix && '-' }}${{ inputs.cache-key-suffix }}-


### PR DESCRIPTION
In the case an `input.cache-key-suffix` is defined - cache keys will look like:

```
Linux-golangsmoke-test-228627ea7...
```

with this update - adds a dash for readability in the [cache entity viewer](https://github.blog/changelog/2022-10-20-manage-caches-in-your-actions-workflows-from-web-interface/)

E.g.

```
Linux-golang-smoke-test-228627ea7...
```
