### PR TITLE
Bump `actions/setup-go@v4` / slightly more efficient cache key buildup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ jobs:
         with:
           version-file: go.mod
           # alternatively, use `version` input
-          #version: ~1.18
+          #version: ~1.20
           cache-key-suffix: key-suffix # optional input argument
 ```

--- a/action.yml
+++ b/action.yml
@@ -13,22 +13,26 @@ runs:
   using: composite
   steps:
     - name: Setup Golang
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
+        cache: false
         go-version: ${{ inputs.version }}
         go-version-file: ${{ inputs.version-file }}
-    - name: Determine cache paths
-      id: golang-path
+    - name: Determine cache paths/cache key
+      id: vars
       run: |
         echo "build=$(go env GOCACHE)" >>"$GITHUB_OUTPUT"
         echo "module=$(go env GOMODCACHE)" >>"$GITHUB_OUTPUT"
+        cacheKeyRoot="${{ runner.os }}-golang${{ inputs.cache-key-suffix && '-' }}${{ inputs.cache-key-suffix }}-"
+        echo "cache-key-restore=$cacheKeyRoot" >>"$GITHUB_OUTPUT"
+        echo "cache-key=${cacheKeyRoot}${{ hashFiles('**/go.sum') }}" >>"$GITHUB_OUTPUT"
       shell: bash
     - name: Setup Golang cache
       uses: actions/cache@v3
       with:
         path: |
-          ${{ steps.golang-path.outputs.build }}
-          ${{ steps.golang-path.outputs.module }}
-        key: ${{ runner.os }}-golang${{ inputs.cache-key-suffix && '-' }}${{ inputs.cache-key-suffix }}-${{ hashFiles('**/go.sum') }}
+          ${{ steps.vars.outputs.build }}
+          ${{ steps.vars.outputs.module }}
+        key: ${{ steps.vars.outputs.cache-key }}
         restore-keys: |
-          ${{ runner.os }}-golang${{ inputs.cache-key-suffix && '-' }}${{ inputs.cache-key-suffix }}-
+          ${{ steps.vars.outputs.cache-key-restore }}


### PR DESCRIPTION
- Bump [`actions/setup-go@v4`](https://github.com/actions/setup-go/releases/tag/v4.0.0) (not using internal caching).
- Building up cache keys/restore key once (DRY).
