### PR TITLE
Implment use of `format()` with `inputs.cache-key-suffix` being non-empty

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
       run: |
         echo "build=$(go env GOCACHE)" >>"$GITHUB_OUTPUT"
         echo "module=$(go env GOMODCACHE)" >>"$GITHUB_OUTPUT"
-        cacheKeyRoot="${{ runner.os }}-golang${{ inputs.cache-key-suffix && '-' }}${{ inputs.cache-key-suffix }}-"
+        cacheKeyRoot="${{ runner.os }}-golang${{ inputs.cache-key-suffix && format('-{0}',inputs.cache-key-suffix) }}-"
         echo "cache-key-restore=$cacheKeyRoot" >>"$GITHUB_OUTPUT"
         echo "cache-key=${cacheKeyRoot}${{ hashFiles('**/go.sum') }}" >>"$GITHUB_OUTPUT"
       shell: bash


### PR DESCRIPTION
A slight improvement of readability using a [`format()`](https://docs.github.com/en/actions/learn-github-actions/expressions#format) expression for string building.