### PR TITLE
GitHub actions bump

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: Setup Golang
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         cache: false
         go-version: ${{ inputs.version }}

--- a/action.yml
+++ b/action.yml
@@ -23,18 +23,19 @@ runs:
     - name: Determine cache paths/cache key
       id: vars
       run: |
-        echo "build=$(go env GOCACHE)" >>"$GITHUB_OUTPUT"
-        echo "module=$(go env GOMODCACHE)" >>"$GITHUB_OUTPUT"
-        cacheKeyRoot="${{ runner.os }}-golang${{ inputs.cache-key-suffix && format('-{0}',inputs.cache-key-suffix) }}-"
+        echo "path-build=$(go env GOCACHE)" >>"$GITHUB_OUTPUT"
+        echo "path-module=$(go env GOMODCACHE)" >>"$GITHUB_OUTPUT"
+
+        cacheKeyRoot="golang-${{ runner.os }}${{ inputs.cache-key-suffix && format('-{0}',inputs.cache-key-suffix) }}-"
         echo "cache-key-restore=$cacheKeyRoot" >>"$GITHUB_OUTPUT"
         echo "cache-key=${cacheKeyRoot}${{ hashFiles('**/go.sum') }}" >>"$GITHUB_OUTPUT"
       shell: bash
     - name: Setup Golang cache
       uses: actions/cache@v3
       with:
-        path: |
-          ${{ steps.vars.outputs.build }}
-          ${{ steps.vars.outputs.module }}
         key: ${{ steps.vars.outputs.cache-key }}
+        path: |
+          ${{ steps.vars.outputs.path-build }}
+          ${{ steps.vars.outputs.path-module }}
         restore-keys: |
           ${{ steps.vars.outputs.cache-key-restore }}


### PR DESCRIPTION
Bumping GitHub Action versions to those supporting Node.js v20 - [since v16 is now deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).

Also:

- Refactor `cacheKeyRoot` - placing `${{ runner.os }}` after `golang-` key start.
