### PR TITLE
Set `GOTOOLCHAIN=local`, only consider `MAJOR.MINOR` version from `go.mod` version spec

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,15 +14,33 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set GOTOOLCHAIN
-      run: echo "GOTOOLCHAIN=local" >>"$GITHUB_ENV"
+    - name: Resolve Golang version and set GOTOOLCHAIN
+      id: version
+      run: |
+        semver="${{ inputs.version }}"
+        if [[ -n "${{ inputs.version-file }}" ]]; then
+          if [[ ! -f "${{ inputs.version-file }}" ]]; then
+            echo "::error title=Extract Golang version from file::Requested module file not found: ${{ inputs.version-file }}."
+            exit 1
+          fi
+          goVersion=$(cat "${{ inputs.version-file }}" | grep --extended-regexp "^go +[0-9]")
+          # ignore PATCH component - only consider MAJOR.MINOR
+          if [[ $goVersion =~ ^go\ +([0-9]\.[0-9]+) ]]; then
+            semver=${BASH_REMATCH[1]}
+          else
+            echo "::error title=Extract Golang version from file::Unable to locate valid semver from module file: ${{ inputs.version-file }}."
+            exit 1
+          fi
+        fi
+
+        echo "semver=$semver" >>"$GITHUB_OUTPUT"
+        echo "GOTOOLCHAIN=local" >>"$GITHUB_ENV"
       shell: bash
     - name: Setup Golang
       uses: actions/setup-go@v5
       with:
         cache: false
-        go-version: ${{ inputs.version }}
-        go-version-file: ${{ inputs.version-file }}
+        go-version: ${{ steps.version.outputs.semver }}
     - name: Determine cache paths/cache key
       id: vars
       run: |

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set GOTOOLCHAIN
+      run: echo "GOTOOLCHAIN=local" >>"$GITHUB_ENV"
+      shell: bash
     - name: Setup Golang
       uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
This change makes two updates to setup of the Golang from the action:

- Set `GOTOOLCHAIN=local` environment variable, introduced as part of [Go Toolchains](https://go.dev/doc/toolchain) in Golang `1.21`. By setting this variable - Go will be instructed to simply use the bundled Go toolchain and don't attempt to fetch/download an alternative toolchain if the `toolchain goSEMVER` stanza was provided in `go.mod`.
- If the Go version set in `go.mod` includes `MAJOR.MINOR.PATCH` components (e.g. `1.22.0`) then:
  - The https://github.com/actions/setup-go action will explicitly use this version, rather than the latest patch release in the `1.22` series.
  - Insult to injury, this latest patch release of the `1.22.x` series is usually present on the GitHub Actions workflow runner already (no need for download).
  - This second change extracts only the `MAJOR.MINOR` components from the parsed `go.mod` to ensure the latest patch release is used and also avoid download of a non-exist Golang distribution - speeding up the workflow.
  - **Note:** there is already discussion to emulate this behaviour within the https://github.com/actions/setup-go list of current issues, after which time this Bash/grep code can be safely removed to simplify the action.
