### PR TITLE
GitHub Actions bump Node.js `v24` releases

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Flip Group
+Copyright (c) 2026 Flip Group
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Action Golang with cache
 
-GitHub Action for setting up Golang via [actions/setup-go](https://github.com/actions/setup-go) coupled with [actions/cache](https://github.com/actions/cache) to cache Golang module and build cache directories.
+GitHub Action for setting up Golang via [actions/setup-go](https://github.com/actions/setup-go) coupled with [actions/cache](https://github.com/actions/cache) to cache both Golang module and build cache directories.
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
         echo "GOTOOLCHAIN=local" >>"$GITHUB_ENV"
       shell: bash
     - name: Setup Golang
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # @v6.4.0
       with:
         cache: false
         go-version: ${{ steps.version.outputs.semver }}
@@ -52,7 +52,7 @@ runs:
         echo "cache-key=${cacheKeyRoot}${{ hashFiles('**/go.sum') }}" >>"$GITHUB_OUTPUT"
       shell: bash
     - name: Setup Golang cache
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # @v5.0.5
       with:
         key: ${{ steps.vars.outputs.cache-key }}
         path: |

--- a/action.yml
+++ b/action.yml
@@ -20,15 +20,15 @@ runs:
         semver="${{ inputs.version }}"
         if [[ -n "${{ inputs.version-file }}" ]]; then
           if [[ ! -f "${{ inputs.version-file }}" ]]; then
-            echo "::error title=Extract Golang version from file::Requested module file not found: ${{ inputs.version-file }}."
+            echo "::error title=Golang version from module::Requested module file not found: ${{ inputs.version-file }}."
             exit 1
           fi
           goVersion=$(cat "${{ inputs.version-file }}" | grep --extended-regexp "^go +[0-9]")
-          # ignore PATCH component - only consider MAJOR.MINOR
+          # ignore PATCH component, only considering MAJOR.MINOR
           if [[ $goVersion =~ ^go\ +([0-9]\.[0-9]+) ]]; then
             semver=${BASH_REMATCH[1]}
           else
-            echo "::error title=Extract Golang version from file::Unable to locate valid semver from module file: ${{ inputs.version-file }}."
+            echo "::error title=Golang version from module::Unable to determine MAJOR.MINOR semver from module file: ${{ inputs.version-file }}."
             exit 1
           fi
         fi

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
 
         cacheKeyRoot="golang-${{ runner.os }}${{ inputs.cache-key-suffix && format('-{0}',inputs.cache-key-suffix) }}-"
         echo "cache-key-restore=$cacheKeyRoot" >>"$GITHUB_OUTPUT"
-        echo "cache-key=${cacheKeyRoot}${{ hashFiles('**/go.sum') }}" >>"$GITHUB_OUTPUT"
+        echo "cache-key=${cacheKeyRoot}${{ hashFiles('**/go.mod') }}" >>"$GITHUB_OUTPUT"
       shell: bash
     - name: Setup Golang cache
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # @v5.0.5


### PR DESCRIPTION
Applies the following GitHub Action workflow changes:

- Implement the use of GitHub Actions compatible with Node.js `v24`.
- Swap out the use of version tags for external actions to full SHA-1 commits to defeat action tainting / supply chain attacks.
